### PR TITLE
Use NuGet's V3 API during build

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -13,6 +13,6 @@
   <packageSources>
     <clear />
     <add key="CBT" value="https://www.myget.org/F/cbt/api/v3/index.json" />
-    <add key="NuGet.org" value="https://www.nuget.org/api/v2/" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We strongly recommend moving to V3 API as it provides more reliable builds and [security improvements](https://blog.nuget.org/20180810/Introducing-Repository-Signatures.html).

The change is super simple:
Replace `https://www.nuget.org/api/v2/` with `https://api.nuget.org/v3/index.json`