### PR TITLE
Update mspms.h to be compatible with MinGW GCC <= 5.1.0

### DIFF
--- a/src/include/mspms.h
+++ b/src/include/mspms.h
@@ -49,6 +49,17 @@ DEFINE_GUID(
 #endif
 
 #include <WS2tcpip.h>
+#if !defined(_WS2IPDEF_) && !defined(_INC_WS2IPDEF) // latter for GCC 4.9.2
+
+typedef u_short ADDRESS_FAMILY;
+
+typedef union _SOCKADDR_INET {
+  SOCKADDR_IN    Ipv4;
+  SOCKADDR_IN6   Ipv6;
+  ADDRESS_FAMILY si_family;
+} SOCKADDR_INET, *PSOCKADDR_INET;
+
+#endif
 #include <windows.h>
 
 
@@ -72,6 +83,15 @@ DEFINE_GUID(
 #endif
 #ifndef _Outptr_
 #define _Outptr_
+#endif
+#ifndef _In_opt_
+#define _In_opt_
+#endif
+#ifndef _Out_opt_
+#define _Out_opt_
+#endif
+#ifndef _Outptr_opt_
+#define _Outptr_opt_
 #endif
 
 


### PR DESCRIPTION
On MinGW (TDM) build of 32-bit GCC 5.1.0, which is currently bundled with
Code::Blocks 17.12 IDE, ws2ipdef.h header is missing, therefore ADDRESS_FAMILY
and _SOCKADDR_INET types end up not defined in msmps.h. This also affects
earlier 32-bit GCC versions (tested on TDM 4.9.2). Provided patch introduces
missing typedefs when required.
Additionally, the following SAL annotations are needed for MinGW GCC <= 5.1.0:
_Outptr_opt_ (always), _Out_opt_, _In_opt_ (if including mspms.h before mpi.h).
NOTE: this is backward-compatibility patch, it is not required for newer
MinGW GCC builds (tested on MinGW-w64 8.1.0, both 32- and 64-bit).