### PR TITLE
Fix undefined references to PtrToInt and IntToPtr

### DIFF
--- a/src/mpi/common/mpidef.h
+++ b/src/mpi/common/mpidef.h
@@ -135,13 +135,13 @@ typedef MPIU_Bsize_t MPIDI_msg_sz_t;
  */
 
 /* PtrToInt converts a pointer to a int type, truncating bits if necessary */
-#define MPIU_PtrToInt PtrToInt
+#define MPIU_PtrToInt(p) ((INT)(INT_PTR) (p) )
 
 /* PtrToAint converts a pointer to an MPI_Aint type, truncating bits if necessary */
 #define MPIU_PtrToAint(a) ((MPI_Aint)(INT_PTR) (a) )
 
 /* IntToPtr converts a int to a pointer type, extending bits if necessary */
-#define MPIU_IntToPtr IntToPtr
+#define MPIU_IntToPtr(i) ((VOID *)(INT_PTR)((int)i))
 
 
 //


### PR DESCRIPTION
After building MSMPI i had unresolved symbols to `PtrToInt` and `IntTpPtr` in the resulting libraries. This MR suggests to replace the calls to those functions that are defined in `Basestd.h` by there macro implemtations. Please note that `MPIU_PtrToAint` is already defined in terms of an inline macro.