### PR TITLE
Fixed Buffer Size for reading MSMPI_ACCEPT_HOST env variable for long Quad-dotted IPv4 Addresses

### DIFF
--- a/src/mpi/msmpi/mpid/DynProcServer.cpp
+++ b/src/mpi/msmpi/mpid/DynProcServer.cpp
@@ -292,7 +292,7 @@ AdjustBindingHost(
     RPC_STATUS status;
     HRESULT    hr;
 
-    char  friendlyName[MAX_COMPUTERNAME_LENGTH];
+    char  friendlyName[MAX_COMPUTERNAME_LENGTH+1];
     friendlyName[0] = '\0';
     DWORD err = MPIU_Getenv(
         "MSMPI_ACCEPT_HOST",


### PR DESCRIPTION
Fixed Buffer Size for reading MSMPI_ACCEPT_HOST env variable for long Quad-dotted IPv4 Addresses
Based on issue found from customer:

have validated the issue with the following test code:

MPI_Init(&argc, &argv);
int myRank;
MPI_Comm_rank(MPI_COMM_WORLD, &myRank);

char friendlyName[MAX_COMPUTERNAME_LENGTH+1];

if (myRank == 0) {
friendlyName[0] = '\0';
const char *env_var = ("MSMPI_ACCEPT_HOST");
bool ret = SetEnvironmentVariableA(env_var, "255.255.255.255");
if (ret)
{
    std::cout << "SetEnvironmentVariableA succeeded" << std::endl;
}
else
{
    std::cout << "SetEnvironmentVariableA failed" << std::endl;
}
DWORD charCopied = GetEnvironmentVariableA(env_var, friendlyName, (DWORD)(sizeof(friendlyName)));
printf("charCopied: %d\n", charCopied);
if (charCopied == MAX_COMPUTERNAME_LENGTH)
{
    std::cout << "GetEnvironmentVariableA succeeded" << std::endl;
}
else if (charCopied > DWORD(sizeof(friendlyName)))
{
    std::cout << "Insufficient buffer" << std::endl;
}
else
{
    std::cout << "GetEnvironmentVariableA failed" << std::endl;
}
printf("friendlyName: %s\n", friendlyName);


}

MPI_Bcast(friendlyName, MAX_COMPUTERNAME_LENGTH, MPI_CHAR, 0, MPI_COMM_WORLD);

// Print the friendlyName for each process
std::cout << "Process " << myRank << " has friendlyName: " << friendlyName << std::endl;

MPI_Finalize();
When the MSMPI env variable is set to 255.255.255.255 and if the buffer size is only 15, then the GetEnvironmentVariableW function will not copy the environment variable into the char array, and the processes will printout empty strings. When I set the buffer size to MAX_COMPUTERNAME_LENGTH + 1 (16), then we do not have this issue, and the number of characters copied , excluding the null character (returned from GetEnvironmentVariableW ) is 15 (as it should be). MPIU_Getenv function checks if the returned character count from GetEnvVariableW function is larger than the buffer size and returns an error, which is what the customer must have been seeing, as when the buffer size is 15 only, the function returns 16. Conceptually, this also makes sense, we need an extra char for the null-terminator